### PR TITLE
Fix hero image not loading on GitHub Pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,7 @@
  * @type {import('gatsby').GatsbyConfig}
  */
 module.exports = {
+  pathPrefix: "/evolve-website",
   siteMetadata: {
     title: `Spoken English Master Course`,
     description: `Spoken English Master Course by Ayesha Ameer`,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "0BSD",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,css}\"",
     "start": "gatsby develop",


### PR DESCRIPTION
## Summary
- configure `pathPrefix` for GitHub Pages deployment
- run build with `--prefix-paths` so assets load under the repo directory

## Testing
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451fe7045c83209419e9afadc77c96